### PR TITLE
Added -e to expand newlines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ upload: depend
 # produce a version string that is embedded into the binary that captures the branch, the date
 # and the commit we're building
 version:
-	@echo "package main\n\nconst VV = \"$(NAME) $(TRAVIS_BRANCH) - $(DATE) - $(TRAVIS_COMMIT)\"" \
+	@echo -e "package main\n\nconst VV = \"$(NAME) $(TRAVIS_BRANCH) - $(DATE) - $(TRAVIS_COMMIT)\"" \
 	  >version.go
 	@echo "version.go: `cat version.go`"
 


### PR DESCRIPTION
was getting this:

> [root@vm right_api_cmd]# make
> version.go: package main\n\nconst VV = "rs-api dev - 2015-03-06 08:03:48 - master"
> go get golang.org/x/tools/cmd/cover github.com/onsi/ginkgo/ginkgo >github.com/rlmcpherson/s3gof3r/gof3r github.com/coddingtonbear/go-jsonselect
> go build -o rs-api .
> # _/root/right_api_cmd
> 
> ./version.go:1: syntax error: unexpected \
> package main
> ./version.go:1: syntax error: unexpected name, expecting semicolon or newline
> make: **\* [rs-api] Error 2

I checked the version.go file and it looked like it had some unexpanded \n's
